### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -54,7 +54,7 @@ class ArticlePresenter extends BasePresenter
 
 	/**
 	 * @var Kdyby\Doctrine\EntityDao
-	 * @autowire(MyApp\Blog\Article, factory=\Kdyby\Doctrine\IEntityDaoFactory)
+	 * @autowire(MyApp\Blog\Article, factory=\Kdyby\Doctrine\EntityDaoFactory)
 	 */
 	protected $factoryResult;
 


### PR DESCRIPTION
You don't have the "I" in the real interface name for whatever reason (I prefer interfaces with "I"). https://github.com/Kdyby/Doctrine/blob/master/src/Kdyby/Doctrine/EntityDaoFactory.php
