### PR TITLE
Fixed usage of autowire annotations in traits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 	"require": {
 		"nette/di": "~2.2@dev",
 		"nette/application": "~2.2@dev",
+		"nette/reflection": "~2.2@dev",
 		"tracy/tracy": "~2.2@dev"
 	},
 	"require-dev": {
@@ -34,7 +35,6 @@
 		"nette/mail": "~2.2@dev",
 		"nette/neon": "~2.2@dev",
 		"nette/php-generator": "~2.2@dev",
-		"nette/reflection": "~2.2@dev",
 		"nette/robot-loader": "~2.2@dev",
 		"nette/safe-stream": "~2.2@dev",
 		"nette/security": "~2.2@dev",

--- a/src/Kdyby/Autowired/AutowireProperties.php
+++ b/src/Kdyby/Autowired/AutowireProperties.php
@@ -198,7 +198,11 @@ trait AutowireProperties
 			}
 			$expandedType = NULL;
 			if (method_exists('Nette\Reflection\AnnotationsParser', 'expandClassName')) {
-			    $expandedType = Nette\Reflection\AnnotationsParser::expandClassName($annotationValue, $prop->getDeclaringClass());
+				$expandedType = Nette\Reflection\AnnotationsParser::expandClassName($annotationValue,
+					method_exists('Nette\Reflection\Helpers', 'getDeclaringClass') && $prop instanceof \ReflectionProperty
+						? Nette\Reflection\Helpers::getDeclaringClass($prop)
+						: $prop->getDeclaringClass()
+				);
 			}
 
 			if ($expandedType && (class_exists($expandedType) || interface_exists($expandedType))) {

--- a/tests/KdybyTests/Autowired/AutowireProperties.phpt
+++ b/tests/KdybyTests/Autowired/AutowireProperties.phpt
@@ -159,6 +159,18 @@ class AutowirePropertiesTest extends ContainerTestCase
 		Assert::true($presenter->service instanceof AliasedService);
 	}
 
+	public function testTraitUsage()
+	{
+		if (!method_exists('Nette\Reflection\Helpers', 'getDeclaringClass')) {
+			Tester\Environment::skip('Correct raits usage requires nette/reflection 2.3.');
+		}
+	
+		$presenter = new WithTraitPresenter();
+
+		$this->container->callMethod(array($presenter, 'injectProperties'));
+		Assert::true($presenter->service instanceof SampleService);
+	}
+
 }
 
 
@@ -270,7 +282,8 @@ class TypoPropertyAnnotationPresenter extends Nette\Application\UI\Presenter
 
 
 
-class PropertyWithUsePresenter extends Nette\Application\UI\Presenter {
+class PropertyWithUsePresenter extends Nette\Application\UI\Presenter
+{
 
 	use Kdyby\Autowired\AutowireProperties;
 
@@ -279,6 +292,16 @@ class PropertyWithUsePresenter extends Nette\Application\UI\Presenter {
 	 * @autowire
 	 */
 	public $service;
+
+}
+
+
+
+class WithTraitPresenter extends Nette\Application\UI\Presenter
+{
+
+	use Kdyby\Autowired\AutowireProperties;
+	use \KdybyTests\Autowired\UseExpansion\TraitSample;
 
 }
 
@@ -307,6 +330,20 @@ run(new AutowirePropertiesTest());
 
 namespace KdybyTests\Autowired\UseExpansion;
 
-class ImportedService {
+use KdybyTests\Autowired\SampleService as AliasedService;
+
+class ImportedService
+{
+
+}
+
+trait TraitSample
+{
+
+	/**
+	 * @var AliasedService
+	 * @autowire
+	 */
+	public $service;
 
 }


### PR DESCRIPTION
You might want to wait with merging this until nette 2.3 is out.