### PR TITLE
Fix compatibility with Nette 2.4 - with using Nette/Reflection

### DIFF
--- a/src/Kdyby/Autowired/AutowireComponentFactories.php
+++ b/src/Kdyby/Autowired/AutowireComponentFactories.php
@@ -71,7 +71,9 @@ trait AutowireComponentFactories
 		}
 
 		$rc = $this->getReflection();
-		if(!$rc instanceof ClassType) $rc = new ClassType($rc->getName());
+		if(!$rc instanceof ClassType) {
+			$rc = new ClassType($rc->getName());
+		}
 
 		$ignore = class_parents('Nette\Application\UI\Presenter') + array('ui' => 'Nette\Application\UI\Presenter');
 		foreach ($rc->getMethods() as $method) {
@@ -138,7 +140,9 @@ trait AutowireComponentFactories
 		$method = 'createComponent' . $ucName;
 		if ($ucName !== $name && method_exists($this, $method)) {
 			$classReflection = $this->getReflection();
-			if(!$classReflection instanceof ClassType) $classReflection = new ClassType($classReflection->getName());
+			if(!$classReflection instanceof ClassType) {
+				$classReflection = new ClassType($classReflection->getName());
+			}
 			$reflection = $classReflection->getMethod($method);
 			if ($reflection->getName() !== $method) {
 				return;

--- a/src/Kdyby/Autowired/AutowireComponentFactories.php
+++ b/src/Kdyby/Autowired/AutowireComponentFactories.php
@@ -71,6 +71,8 @@ trait AutowireComponentFactories
 		}
 
 		$rc = $this->getReflection();
+		if(!$rc instanceof ClassType) $rc = new ClassType($rc->getName());
+
 		$ignore = class_parents('Nette\Application\UI\Presenter') + array('ui' => 'Nette\Application\UI\Presenter');
 		foreach ($rc->getMethods() as $method) {
 			/** @var Property $prop */
@@ -135,11 +137,13 @@ trait AutowireComponentFactories
 		$ucName = ucfirst($name);
 		$method = 'createComponent' . $ucName;
 		if ($ucName !== $name && method_exists($this, $method)) {
-			$reflection = $this->getReflection()->getMethod($method);
+			$classReflection = $this->getReflection();
+			if(!$classReflection instanceof ClassType) $classReflection = new ClassType($classReflection->getName());
+			$reflection = $classReflection->getMethod($method);
 			if ($reflection->getName() !== $method) {
 				return;
 			}
-			$parameters = $reflection->parameters;
+			$parameters = $reflection->getParameters();
 
 			$args = array();
 			if (($first = reset($parameters)) && !$first->className) {

--- a/src/Kdyby/Autowired/AutowireProperties.php
+++ b/src/Kdyby/Autowired/AutowireProperties.php
@@ -74,6 +74,8 @@ trait AutowireProperties
 
 		$ignore = class_parents('Nette\Application\UI\Presenter') + array('ui' => 'Nette\Application\UI\Presenter');
 		foreach ($this->getReflection()->getProperties() as $prop) {
+			if(!$prop instanceof Property) $prop = new Property($prop->getDeclaringClass()->getName(), $prop->getName());
+
 			/** @var Property $prop */
 			if (!$this->validateProperty($prop, $ignore)) {
 				continue;

--- a/src/Kdyby/Autowired/AutowireProperties.php
+++ b/src/Kdyby/Autowired/AutowireProperties.php
@@ -74,7 +74,9 @@ trait AutowireProperties
 
 		$ignore = class_parents('Nette\Application\UI\Presenter') + array('ui' => 'Nette\Application\UI\Presenter');
 		foreach ($this->getReflection()->getProperties() as $prop) {
-			if(!$prop instanceof Property) $prop = new Property($prop->getDeclaringClass()->getName(), $prop->getName());
+			if(!$prop instanceof Property) {
+				$prop = new Property($prop->getDeclaringClass()->getName(), $prop->getName());
+			}
 
 			/** @var Property $prop */
 			if (!$this->validateProperty($prop, $ignore)) {

--- a/tests/KdybyTests/bootstrap.php
+++ b/tests/KdybyTests/bootstrap.php
@@ -38,7 +38,7 @@ function id($val) {
 }
 
 function run(Tester\TestCase $testCase) {
-	$testCase->run(isset($_SERVER['argv'][1]) ? $_SERVER['argv'][1] : NULL);
+	$testCase->run();
 }
 
 


### PR DESCRIPTION
Hi,
I know that there is already another pull request to fix this, but I went with a bit different approach.
Because Kdyby/Autowired requires Nette/Reflection (and I think that most of the final projects do as well) I keep using this package. Unlike the fixes in the other PR.

This PR contains 2 commits - one fixing the problem with compatibility and second one is fixing Nette/Tester.

--

**The Tester problem:**
Following code for running tests in your run() function in bootstrap.php is no longer working, because this functionality appears to be moved inside that method.
```php
$testCase->run(isset($_SERVER['argv'][1]) ? $_SERVER['argv'][1] : NULL);
```
Change: https://github.com/nette/tester/commit/f3b81790acf2355d5a06fc6e553ca8d76c065fe9

-- 
*Yes, this solution is not really nice. I was looking if it would be possible to remove need of Nette/Reflections but ... well, you need them anyway for checking annotations and you get them from Nette 2.3 and previous versions*