### PR TITLE
use callable $getter instead of $resolver

### DIFF
--- a/src/Kdyby/Autowired/AutowireComponentFactories.php
+++ b/src/Kdyby/Autowired/AutowireComponentFactories.php
@@ -130,8 +130,9 @@ trait AutowireComponentFactories
 			if ($first !== false && !$first->getClassName()) {
 				$args[] = $name;
 			}
-
-			$args = Nette\DI\Resolver::autowireArguments($methodReflection, $args, $sl);
+			
+			$resolver = [$sl, 'findAutowired'];
+			$args = Nette\DI\Resolver::autowireArguments($methodReflection, $args, $resolver);
 			$component = $this->{$method}(...$args);
 			if (!$component instanceof Nette\ComponentModel\IComponent && !isset($this->components[$name])) {
 				throw new Nette\UnexpectedValueException("Method $methodReflection did not return or create the desired component.");


### PR DESCRIPTION
compatibility with DI/Resolver since this commit https://github.com/nette/di/commit/d9621e65fe207069b59b94f3a2f12feab8d09c9a#diff-6682ea383870132c0a5bfc2133f557d1R456